### PR TITLE
Add privacy control for group admins

### DIFF
--- a/player/BookingDetails/BookingDetails.js
+++ b/player/BookingDetails/BookingDetails.js
@@ -42,6 +42,9 @@ function populateBookingDetails(booking) {
   document.getElementById("totalPrice").textContent = booking.total_price + " ₪";
   document.getElementById("bookingId").textContent = booking.booking_id;
 
+  // store group id globally for later updates
+  window.currentGroupId = booking.group_id;
+
   // ✅ عرض الخصوصية
   const privacyToggle = document.getElementById("privacyToggle");
   const passwordSection = document.getElementById("passwordSection");
@@ -169,6 +172,7 @@ function initializePrivacyToggle() {
   // ✅ Host can toggle
   privacyToggle?.addEventListener('click', function () {
     window.isPrivate = !window.isPrivate;
+    const newPrivacy = window.isPrivate ? 'private' : 'public';
 
     if (window.isPrivate) {
       this.innerHTML = '<span class="privacy-status">Private</span><span class="privacy-icon">🔒</span>';
@@ -180,6 +184,28 @@ function initializePrivacyToggle() {
       this.classList.remove('private');
       passwordSection.style.display = 'none';
       showNotification('Room is now public. Anyone can join!', 'info');
+    }
+
+    // notify backend about the change
+    if (window.currentGroupId) {
+      const formData = new URLSearchParams();
+      formData.append('group_id', window.currentGroupId);
+      formData.append('privacy', newPrivacy);
+
+      fetch('updatePrivacy.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formData.toString()
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (!data.success) {
+            showNotification(data.error || 'Failed to update privacy', 'error');
+          }
+        })
+        .catch(() => {
+          showNotification('Failed to update privacy', 'error');
+        });
     }
   });
 

--- a/player/BookingDetails/updatePrivacy.php
+++ b/player/BookingDetails/updatePrivacy.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+require_once '../../db.php';
+
+header('Content-Type: application/json');
+
+$username = $_SESSION['user_id'] ?? '';
+$groupId = $_POST['group_id'] ?? null;
+$privacy = $_POST['privacy'] ?? null;
+
+if (!$username) {
+    echo json_encode(['success' => false, 'error' => 'Not logged in']);
+    exit;
+}
+
+if (!$groupId || ($privacy !== 'public' && $privacy !== 'private')) {
+    echo json_encode(['success' => false, 'error' => 'Invalid input']);
+    exit;
+}
+
+// Verify that the current user is the group admin
+$stmt = $conn->prepare('SELECT created_by, group_password FROM groups WHERE group_id = ?');
+$stmt->bind_param('i', $groupId);
+$stmt->execute();
+$result = $stmt->get_result();
+$group = $result->fetch_assoc();
+$stmt->close();
+
+if (!$group || $group['created_by'] !== $username) {
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+
+$groupPassword = null;
+if ($privacy === 'private') {
+    // keep existing password if already set
+    $groupPassword = $group['group_password'] ?? null;
+}
+
+$stmt = $conn->prepare('UPDATE groups SET privacy = ?, group_password = ? WHERE group_id = ?');
+$stmt->bind_param('ssi', $privacy, $groupPassword, $groupId);
+$success = $stmt->execute();
+$stmt->close();
+
+echo json_encode(['success' => $success]);
+?>


### PR DESCRIPTION
## Summary
- enable storing the current group id
- allow host to notify backend when privacy is toggled
- create `updatePrivacy.php` to persist changes

## Testing
- `php -l player/BookingDetails/updatePrivacy.php`

------
https://chatgpt.com/codex/tasks/task_e_68824b38dc58832abe3e98e138bc0b17