### PR TITLE
Enhance BookingDetails member and privacy logic

### DIFF
--- a/player/BookingDetails/BookingDetails.css
+++ b/player/BookingDetails/BookingDetails.css
@@ -567,13 +567,13 @@ body {
   transform: translateY(-1px);
 }
 
-.friend-btn.friends {
+.friend-btn.remove-friend {
   background: linear-gradient(135deg, var(--secondary), #66bb6a);
   color: white;
   border-color: transparent;
 }
 
-.friend-btn.friends:hover {
+.friend-btn.remove-friend:hover {
   background: linear-gradient(135deg, #1db954, var(--secondary));
 }
 

--- a/player/BookingDetails/BookingDetails.php
+++ b/player/BookingDetails/BookingDetails.php
@@ -1,5 +1,12 @@
 <?php
 session_start();
-include 'BookingDetails.html'; 
+
+$currentUsername = $_SESSION['user_id'] ?? '';
+
+include 'BookingDetails.html';
+
+// expose the logged in user to JavaScript
+echo "<script>window.currentUsername = " . json_encode($currentUsername) . ";</script>";
+
 exit();
 ?>

--- a/player/BookingDetails/updatePrivacy.php
+++ b/player/BookingDetails/updatePrivacy.php
@@ -1,0 +1,55 @@
+<?php
+session_start();
+require_once '../../db.php';
+
+header('Content-Type: application/json');
+
+$username = $_SESSION['user_id'] ?? '';
+$groupId = $_POST['group_id'] ?? null;
+$privacy = $_POST['privacy'] ?? null;
+
+if (!$username) {
+    echo json_encode(['success' => false, 'error' => 'Not logged in']);
+    exit;
+}
+
+if (!$groupId || ($privacy !== 'public' && $privacy !== 'private')) {
+    echo json_encode(['success' => false, 'error' => 'Invalid input']);
+    exit;
+}
+
+// Verify that the current user is the group admin
+$stmt = $conn->prepare('SELECT created_by, group_password FROM groups WHERE group_id = ?');
+$stmt->bind_param('i', $groupId);
+$stmt->execute();
+$result = $stmt->get_result();
+$group = $result->fetch_assoc();
+$stmt->close();
+
+if (!$group || $group['created_by'] !== $username) {
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+
+$groupPassword = null;
+if ($privacy === 'private') {
+    // keep existing password if already set, otherwise generate one
+    if (!empty($group['group_password'])) {
+        $groupPassword = $group['group_password'];
+    } else {
+        $groupPassword = 'BP' . rand(1000,9999) . '-' . substr(md5(uniqid()),0,4);
+    }
+}
+
+$stmt = $conn->prepare('UPDATE groups SET privacy = ?, group_password = ? WHERE group_id = ?');
+$stmt->bind_param('ssi', $privacy, $groupPassword, $groupId);
+$success = $stmt->execute();
+$stmt->close();
+
+$response = ['success' => $success];
+if ($success && $privacy === 'private') {
+    $response['password'] = $groupPassword;
+}
+
+echo json_encode($response);
+?>


### PR DESCRIPTION
## Summary
- show paid amount and friend status for each member
- allow host to toggle privacy and generate password
- expose friendship and payments data from backend
- adjust styles for add/remove friend buttons

## Testing
- `php -l player/BookingDetails/getBookingDetails.php`
- `php -l player/BookingDetails/updatePrivacy.php`
- `php -l player/BookingDetails/BookingDetails.php`


------
https://chatgpt.com/codex/tasks/task_e_68824b38dc58832abe3e98e138bc0b17